### PR TITLE
Interactive CLI tool to create Pelican content

### DIFF
--- a/pelican_tools/article.py
+++ b/pelican_tools/article.py
@@ -1,0 +1,87 @@
+import argparse
+import datetime
+import getpass
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from pelican.tools.pelican_import import build_header, build_markdown_header
+from pelican.utils import slugify
+
+ACCEPTED_MARKUPS = ["md", "rst"]
+DEFAULT_AUTHOR = getpass.getuser()
+try:
+    from markdown import Markdown
+except ImportError:
+    DEFAULT_MARKUP = "rst"
+else:
+    DEFAULT_MARKUP = "md"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="An article creator for Pelican")
+
+    parser.add_argument("title", help="The article title")
+    parser.add_argument(
+        "-a",
+        "--author",
+        default=DEFAULT_AUTHOR,
+        help=f"The author of the article (default: `{DEFAULT_AUTHOR}`)",
+    )
+    parser.add_argument(
+        "-t", "--tags", default="", help="Add tags to the article (separated by comma)",
+    )
+    parser.add_argument("-c", "--category", help="Set the article category")
+    parser.add_argument(
+        "-s",
+        "--slug",
+        help="Define the article slug (default: generates slug from title)",
+    )
+    parser.add_argument(
+        "-p",
+        "--path",
+        default="content/posts",
+        help="Path to save the article file (default: `content/posts`)",
+    )
+    parser.add_argument(
+        "-m",
+        "--markup",
+        default=DEFAULT_MARKUP,
+        help=(
+            "The markup style for the article. "
+            f"Accepts: {', '.join(ACCEPTED_MARKUPS)}. "
+            "If the `markdown` package is installed defaults to `md`, "
+            "otherwise, defaults to `rst`."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.markup.lower() not in ACCEPTED_MARKUPS:
+        raise ValueError(
+            "%s is not a valid markup format, availabe options are %s " %
+            (args.markup, ", ".join(ACCEPTED_MARKUPS)),
+        )
+
+    file_dir = Path() / args.path
+
+    slug = slugify(args.slug if args.slug else args.title).replace(" ", "-")
+    date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    tags = args.tags.split(",")
+
+    if args.markup.lower() == "md":
+        ext = ".md"
+        header_generator_fn = build_markdown_header
+    else:
+        ext = ".rst"
+        header_generator_fn = build_header
+
+    file_path = file_dir / (slug + ext).replace("-", "_")
+    header = header_generator_fn(
+        args.title, date, args.author, [args.category], tags, slug
+    )
+
+    with open(file_path, "w") as article_file:
+        article_file.write(header)
+
+    print('Article file created at %s' % file_path)

--- a/pelican_tools/article.py
+++ b/pelican_tools/article.py
@@ -2,14 +2,19 @@
 """
 
 import argparse
-import datetime
+from datetime import datetime
 import getpass
+import sys
 from pathlib import Path
 
+import click
 from pelican.tools.pelican_import import build_header, build_markdown_header
 from pelican.utils import slugify
+import PyInquirer
 
-ACCEPTED_MARKUPS = ["md", "rst"]
+MARKUP_CHOICES = ["md", "rst"]
+TYPE_CHOICES = ["article", "page"]
+STATUS_CHOICES = ["draft", "hidden", "published"]
 DEFAULT_AUTHOR = getpass.getuser()
 
 try:
@@ -20,7 +25,7 @@ else:
     DEFAULT_MARKUP = "md"
 
 
-def validate(parsed_args):
+def validate(markup, **parsed_args):
     """Validates the parsed arguments and raises appropriated exceptions for
     the validation issues found.
 
@@ -28,14 +33,25 @@ def validate(parsed_args):
         parsed_args: The parsed arguments received from the system.
     """
 
-    if parsed_args.markup.lower() not in ACCEPTED_MARKUPS:
+    if markup.lower() not in MARKUP_CHOICES:
         raise ValueError(
             "%s is not a valid markup format, available options are %s "
-            % (parsed_args.markup, ", ".join(ACCEPTED_MARKUPS)),
+            % (markup, ", ".join(MARKUP_CHOICES)),
         )
 
 
-def generate_article(validated_args):
+def generate_article(
+    content_type,
+    title,
+    slug=None,
+    tags=None,
+    markup=None,
+    category=None,
+    author=None,
+    path=None,
+    status=None,
+    **kwargs,
+):
     """Generates the article values from the validated parsed arguments.
 
     Args:
@@ -46,31 +62,46 @@ def generate_article(validated_args):
         file_path
     """
 
-    slug = slugify(validated_args.slug or validated_args.title)
-    slug = slug.replace(" ", "-")
-    date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
-    tags = validated_args.tags.split(",")
+    slug = slugify(slug or title).replace(" ", "-")
 
-    if validated_args.markup.lower() == "md":
-        ext = ".md"
+    if markup.lower() == "md":
         header_generator_fn = build_markdown_header
     else:
-        ext = ".rst"
         header_generator_fn = build_header
 
+    if content_type == "article":
+        date = datetime.now().strftime("%Y-%m-%d %H:%M")
+    else:
+        date = None
+
     file_content = header_generator_fn(
-        validated_args.title,
+        title,
         date,
-        validated_args.author,
-        [validated_args.category],
-        tags,
-        slug
+        author,
+        [category] if category else None,
+        tags.split(",") if tags else None,
+        slug,
+        status,
     )
 
-    file_dir = Path() / validated_args.path
-    file_path = file_dir / (slug + ext).replace("-", "_")
+    file_dir = Path() / path
+    file_path = file_dir / f"{slug}.{markup}"
 
     return file_content, file_path
+
+
+def review(file_content):
+    questions = [
+        {
+            "type": "editor",
+            "name": "content",
+            "message": "Review",
+            "default": file_content,
+            "eargs": {"editor": "default", "ext": ".rst"},
+        }
+    ]
+    answer = PyInquirer.prompt(questions)
+    return answer["content"]
 
 
 def save_file(file_content, file_path):
@@ -87,65 +118,122 @@ def save_file(file_content, file_path):
     print("Article file created at %s" % file_path)
 
 
-def parse_args():
-    """Parses the command line string arguments.
+def interactive(values):
+    type_choices = sorted(TYPE_CHOICES, key=lambda x: x != values.get("content_type"))
+    markup_choices = sorted(MARKUP_CHOICES, key=lambda x: x != values.get("markup"))
+    status_choices = sorted(STATUS_CHOICES, key=lambda x: x != values.get("status"))
+    questions = [
+        {
+            "type": "list",
+            "name": "content_type",
+            "message": "Content Type:",
+            "choices": type_choices,
+        },
+        {
+            "type": "input",
+            "name": "title",
+            "message": "Content Title:",
+            "default": values.get("title") or "",
+            "validate": lambda text: bool(text) or "Must provide a title",
+        },
+        {
+            "type": "input",
+            "name": "author",
+            "message": "Author name:",
+            "default": values.get("author") or "",
+        },
+        {
+            "type": "input",
+            "name": "tags",
+            "message": "Tags (comma separated):",
+            "default": values.get("tags") or "",
+        },
+        {
+            "type": "input",
+            "name": "category",
+            "message": "Category:",
+            "default": values.get("category") or "",
+        },
+        {
+            "type": "input",
+            "name": "slug",
+            "message": "Slug:",
+            "default": values.get("slug") or "",
+        },
+        {
+            "type": "list",
+            "name": "status",
+            "message": "Status:",
+            "choices": status_choices,
+        },
+        {
+            "type": "list",
+            "name": "markup",
+            "message": "Markup Style:",
+            "choices": markup_choices,
+        },
+    ]
+    answers = PyInquirer.prompt(questions)
+
+    path_prompt = [
+        {
+            "type": "input",
+            "name": "path",
+            "message": "File path:",
+            "default": f"{values['path']}/{answers['content_type']}s",
+        },
+    ]
+    path_answer = PyInquirer.prompt(path_prompt)
+
+    return {**answers, **path_answer}
+
+
+@click.command()
+@click.option("--title", help="The article title.")
+@click.option(
+    "--content-type",
+    type=click.Choice(TYPE_CHOICES),
+    help="The content type to be created.",
+)
+@click.option(
+    "--author",
+    default=DEFAULT_AUTHOR,
+    help=f"Set the author of the article. (default: `{DEFAULT_AUTHOR}`)",
+)
+@click.option(
+    "--tags", default="", help="Set tags to the article. (separated by comma).",
+)
+@click.option("--category", help="Set the article category.")
+@click.option(
+    "--slug", help="Set a custom article slug. (default: generates slug from title)",
+)
+@click.option(
+    "--status", help="Publication status", type=click.Choice(STATUS_CHOICES),
+)
+@click.option(
+    "--path",
+    default="content",
+    help="Path to save the article file. (default: `content/posts`)",
+)
+@click.option(
+    "--markup",
+    type=click.Choice(MARKUP_CHOICES),
+    default=DEFAULT_MARKUP,
+    help=(
+        "The markup style for the article. "
+        f"Accepts: {', '.join(MARKUP_CHOICES)}. "
+        "If the `markdown` package is installed defaults to `md`, "
+        "otherwise, defaults to `rst`."
+    ),
+)
+@click.option(
+    "--prompt/--noprompt", default=True, help="Disable interactive prompt",
+)
+def main(prompt, **kwargs):
+    """Generates a new article or page file from command line.
     """
-
-    parser = argparse.ArgumentParser(
-        description="An article creator for Pelican"
-    )
-
-    parser.add_argument(
-        "title",
-        help="The article title."
-    )
-    parser.add_argument(
-        "-a",
-        "--author",
-        default=DEFAULT_AUTHOR,
-        help=f"Set the author of the article. (default: `{DEFAULT_AUTHOR}`)",
-    )
-    parser.add_argument(
-        "-t",
-        "--tags",
-        default="",
-        help="Set tags to the article. (separated by comma).",
-    )
-    parser.add_argument(
-        "-c",
-        "--category",
-        help="Set the article category."
-    )
-    parser.add_argument(
-        "-s",
-        "--slug",
-        help="Set a custom article slug. (default: generates slug from title)",
-    )
-    parser.add_argument(
-        "-p",
-        "--path",
-        default="content/posts",
-        help="Path to save the article file. (default: `content/posts`)",
-    )
-    parser.add_argument(
-        "-m",
-        "--markup",
-        default=DEFAULT_MARKUP,
-        help=(
-            "The markup style for the article. "
-            f"Accepts: {', '.join(ACCEPTED_MARKUPS)}. "
-            "If the `markdown` package is installed defaults to `md`, "
-            "otherwise, defaults to `rst`."
-        ),
-    )
-
-    return parser.parse_args()
-
-
-def main():
-    """Generates a new article file from command line string arguments.
-    """
-    parsed_args = parse_args()
-    validate(parsed_args)
-    file_content, file_path = generate_article(parsed_args)
+    parsed_args = interactive(kwargs) if prompt else kwargs
+    validate(**parsed_args)
+    file_content, file_path = generate_article(**parsed_args)
+    file_content = review(file_content) if prompt else file_content
     save_file(file_content, file_path)

--- a/pelican_tools/content.py
+++ b/pelican_tools/content.py
@@ -40,7 +40,7 @@ def validate(markup, **parsed_args):
         )
 
 
-def generate_article(
+def generate_content(
     content_type,
     title,
     slug=None,
@@ -213,7 +213,7 @@ def interactive(values):
 @click.option(
     "--path",
     default="content",
-    help="Path to save the article file. (default: `content/posts`)",
+    help="Path to save the article file. (default: `content/` + content-type)",
 )
 @click.option(
     "--markup",
@@ -234,6 +234,6 @@ def main(prompt, **kwargs):
     """
     parsed_args = interactive(kwargs) if prompt else kwargs
     validate(**parsed_args)
-    file_content, file_path = generate_article(**parsed_args)
+    file_content, file_path = generate_content(**parsed_args)
     file_content = review(file_content) if prompt else file_content
     save_file(file_content, file_path)

--- a/pelican_tools/tests/test_article.py
+++ b/pelican_tools/tests/test_article.py
@@ -1,0 +1,11 @@
+"""Test cases for pelican-article module.
+"""
+
+import pytest
+from pelican_tools.article import parse_args
+
+
+@pytest.mark.parametrize("args,expected_data", [(["Article Title"], dict(title="Article Title")),])
+def test_parse_args(args, expected_data):
+    parsed_args = parse_args(args)
+    assert parsed_args.__dict__ == expected_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "pelican-tools"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+pelican = "^4.2.0"
+click = "^7.1.2"
+PyInquirer = "^1.0.3"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ requires = []
 
 entry_points = {
     'console_scripts': [
-        'pelican-article=pelican_tools.article:main'
+        'pelican-content=pelican_tools.content:main'
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,9 @@ from setuptools import setup
 requires = []
 
 entry_points = {
-    'console_scripts': []
+    'console_scripts': [
+        'pelican-article=pelican_tools.article:main'
+    ]
 }
 
 packages = []


### PR DESCRIPTION
Based on this https://github.com/getpelican/pelican-tools/issues/6 issue, this PR adds a `pelican-content` CLI command to the `pelican-tools` package.

As the repo didn't have any structure for dependencies, tests, etc, I've done a minimum setup of the project but I am more than happy to change it to what it has to be.

To test the command, install the package and run the command `pelican-content` on an environment that has `pelican` installed.